### PR TITLE
rename BCM BT firmware

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -20,7 +20,7 @@ DEVICE_PACKAGE_OVERLAYS += \
 
 PRODUCT_COPY_FILES := \
     $(DEVICE_PATH)/rootdir/system/etc/audio_policy.conf:system/etc/audio_policy.conf \
-    $(DEVICE_PATH)/rootdir/system/etc/BCM4359C0.hcd:system/etc/firmware/BCM43xx.hcd \
+    $(DEVICE_PATH)/rootdir/system/etc/BCM4359C0.hcd:system/etc/firmware/BCM4359C0.hcd \
     $(DEVICE_PATH)/rootdir/system/etc/wifi/bcmdhd.cal:system/etc/wifi/bcmdhd.cal \
     $(DEVICE_PATH)/rootdir/system/etc/sensors/sensor_def_qcomdev.conf:system/etc/sensors/sensor_def_qcomdev.conf \
     $(DEVICE_PATH)/rootdir/system/etc/thermanager.xml:system/etc/thermanager.xml \


### PR DESCRIPTION
we can use the AOSP fw loader without changes

Signed-off-by: Alin Jerpelea <alin.jerpelea@sonymobile.com>